### PR TITLE
Use sinon.createSandbox instead of sinon.sandbox.create

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@
 
 var sinon = require('sinon');
 
-var sandbox = sinon.sandbox.create();
+var sandbox = sinon.createSandbox();
 
 module.exports = sandbox;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "eslint . && jscs . && mocha"
   },
   "peerDependencies": {
-    "sinon": "*"
+    "sinon": ">=3.10.0"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint": "1.1.0",
     "jscs": "2.1.0",
     "mocha": "2.2.5",
+    "sinon": "^6.1.0",
     "wealthfront-javascript": "2.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "sinon": ">=3.10.0"
   },
   "devDependencies": {
-    "sinon": "^6.1.0",
     "chai": "3.2.0",
     "eslint": "1.1.0",
     "jscs": "2.1.0",


### PR DESCRIPTION
This method was added in sinon v3.10.0:

  https://github.com/sinonjs/sinon/pull/1515

and a deprecation warning for sinon.sandbox.create was added in sinon
v5.0.1:

  - https://github.com/sinonjs/sinon/pull/1768
  - https://github.com/sinonjs/sinon/commit/4fc7c65d#diff-7ac78866bb2aab0e4513c3e57f189c88R50

